### PR TITLE
fields-azure: originalFilename removed from blob metadata, see github issue #25

### DIFF
--- a/packages/fields-azure/CHANGELOG.md
+++ b/packages/fields-azure/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @k6-contrib/fields-azure
 
+## 5.0.1
+
+### Patch Changes
+
+- Removed originalFilename from blob metadata which is causing issues for some non-English and special characters. If you need support for this open a new issue and preferably a PR with configuration option to enable disable this meta header.
+
 ## 5.0.0
 
 ### Major Changes

--- a/packages/fields-azure/package.json
+++ b/packages/fields-azure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k6-contrib/fields-azure",
   "description": "Keystone6 Azure Storage File and Image Field Type",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "The KeystoneJS Contrib Development Team",
   "license": "MIT",
   "main": "dist/fields-azure.cjs.js",

--- a/packages/fields-azure/src/lib/blob.ts
+++ b/packages/fields-azure/src/lib/blob.ts
@@ -119,7 +119,7 @@ export const getDataFromStream = async (
     });
 
     await blockBlobClient.setMetadata({
-      originalFilename,
+      // originalFilename, // disabled per github issue #25
       ...(type === 'image'
         ? {
             extension: metadata.extension,


### PR DESCRIPTION
[… issue #25] (fields-azure: originalFilename removed from blob metadata, see github issue #25)