### PR TITLE
Readd the support for resolveInput and afterOperation function hooks

### DIFF
--- a/packages/list-plugins/src/lib/logging.ts
+++ b/packages/list-plugins/src/lib/logging.ts
@@ -38,20 +38,26 @@ export const logging =
   }: ListConfig<ListTypeInfo>): ListConfig<ListTypeInfo> => ({
     hooks: {
       ...hooks,
-      afterOperation: {
-        create: async (args: any) => {
-          await hooks.afterOperation?.create?.(args);
-          afterOperation(args, loggingFn);
-        },
-        update: async (args: any) => {
-          await hooks.afterOperation?.update?.(args);
-          afterOperation(args, loggingFn);
-        },
-        delete: async (args: any) => {
-          await hooks.afterOperation?.delete?.(args);
-          afterOperation(args, loggingFn);
-        },
-      },
+      afterOperation:
+        typeof hooks.afterOperation === 'function' 
+          ? async (args: any) => {
+              await hooks.afterOperation(args);
+              afterOperation(args, loggingFn);
+            }
+          : {
+              create: async (args: any) => {
+                await hooks.afterOperation?.create?.(args);
+                afterOperation(args, loggingFn);
+              },
+              update: async (args: any) => {
+                await hooks.afterOperation?.update?.(args);
+                afterOperation(args, loggingFn);
+              },
+              delete: async (args: any) => {
+                await hooks.afterOperation?.delete?.(args);
+                afterOperation(args, loggingFn);
+              },
+            },
 
       // TODO Disabled until this is supported again
       //@ts-ignore

--- a/packages/list-plugins/src/lib/tracking/byTracking.ts
+++ b/packages/list-plugins/src/lib/tracking/byTracking.ts
@@ -85,8 +85,16 @@ export const byTracking =
         return resolvedData;
       };
 
+      const originalResolveInput = listConfig.hooks?.resolveInput;
       const originalCreateHook = listConfig.hooks?.resolveInput?.create;
       const originalUpdateHook = listConfig.hooks?.resolveInput?.update;
+      const resolveInput =
+        typeof originalResolveInput === 'function'
+          ? composeHook(originalResolveInput, newResolveInput)
+          : {
+              create: composeHook(originalCreateHook, newResolveInput),
+              update: composeHook(originalUpdateHook, newResolveInput),
+            };
 
       return {
         ...listConfig,
@@ -96,10 +104,7 @@ export const byTracking =
         },
         hooks: {
           ...listConfig.hooks,
-          resolveInput: {
-            create: composeHook(originalCreateHook, newResolveInput),
-            update: composeHook(originalUpdateHook, newResolveInput),
-          },
+          resolveInput,
         },
       };
     };


### PR DESCRIPTION
Readd the support for resolveInput and afterOperation function hooks in list-plugins. See the issue reported: https://github.com/keystonejs-contrib/k6-contrib/issues/46